### PR TITLE
Updated for new kippo location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ ADD build/ /tmp/build/
 
 RUN bash /tmp/build/setup-apt-mirrors.sh
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install python-dev openssl python-openssl python-pyasn1 python-twisted subversion
+RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install git python-dev openssl python-openssl python-pyasn1 python-twisted subversion
 
 RUN useradd -d /kippo -s /bin/bash -m kippo -g sudo
-RUN svn checkout http://kippo.googlecode.com/svn/trunk/ /kippo
+RUN git clone https://github.com/desaster/kippo.git /kippo
 RUN mv /kippo/kippo.cfg.dist /kippo/kippo.cfg
 RUN chown kippo /kippo -R
 


### PR DESCRIPTION
Will use git to pull from github location instead of svn checkout from Google code (which is going away).
